### PR TITLE
fix: allow "-" in scopes

### DIFF
--- a/__test__/action.test.mjs
+++ b/__test__/action.test.mjs
@@ -63,6 +63,10 @@ describe("action", () => {
       runAction({}, "feat(cdk8s): use environment based secrets TDE-712"),
       {}
     );
+    assert.deepEqual(
+      runAction({}, "build(dev-deps): bump the aws group with 3 updates TDE-34"),
+      {}
+    );
     assert.deepEqual(runAction({}, "release: v6.46.0"), {
       warning: ["Pull request title does not contain a JIRA ticket!"],
     });

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
             }
 
             if (conventionalRequired !== 'off') {
-              const scopeRegex = conventionalScopes ? conventionalScopes.replace(/,/g, '|') : '[a-z0-9]+'
+              const scopeRegex = conventionalScopes ? conventionalScopes.replace(/,/g, '|') : '[a-z0-9\-]+'
               const typeRegex = `build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|release`
               const conventionalRegex = new RegExp(`^(${typeRegex})(\\(${scopeRegex}\\))?(!)?: [^\\r\\n]+$`)
 


### PR DESCRIPTION
#### Motivation

Dependabot uses `build(dev-deps): ..` as a standard commit message, so allow "-" in scopes

#### Modifcation

Allow "-" in scopes