### PR TITLE
chore: upgrade action and use dependabot to keep it updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Check Pull Request Title
-      uses: actions/github-script@v6
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       env:
         JIRA: ${{ inputs.jira }}
         JIRA_PROJECTS: ${{ inputs.jira-projects }}


### PR DESCRIPTION
v6 is on node16 which will be giving out warnings