### PR TITLE
fix: move context access to env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ on:
 jobs:
   pull-request-lint:
     runs-on: ubuntu-latest
+  
+    permissions:
+      contents: read
+
     steps:
       - uses: linz/action-pull-request-lint@v1
         with:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ on:
   pull_request:
     types: ["opened", "edited", "reopened", "synchronize"]
 
+# This github action requires no permissions
+permissions: {}
+
 jobs:
   pull-request-lint:
     runs-on: ubuntu-latest
-
-    # This github action requires no permissions
-    permissions: {}
 
     steps:
       - uses: linz/action-pull-request-lint@v1

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ on:
 jobs:
   pull-request-lint:
     runs-on: ubuntu-latest
-  
-    permissions:
-      contents: read
+
+    # This github action requires no permissions
+    permissions: {}
 
     steps:
       - uses: linz/action-pull-request-lint@v1

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ runs:
         JIRA_PROJECTS: ${{ inputs.jira-projects }}
         CONVENTIONAL: ${{ inputs.conventional }}
         CONVENTIONAL_SCOPES: ${{ inputs.conventional-scopes }}
+        PULL_REQUEST_TITLE: ${{ context.payload.pull_request.title }}
       with:
         script: |
           try {
@@ -59,7 +60,7 @@ runs:
               }
             }
 
-            const title = context.payload.pull_request.title
+            const title = process.env.PULL_REQUEST_TITLE;
             console.log(`Testing title: '${title}'`)
 
             // The pattern for JIRA ticket format


### PR DESCRIPTION
#### Motivation

Accessing context variables directly can be unsafe, using a env var as a proxy is a safety work around.


#### Modification

Swap to using env var for pull_request_title


#### Verification

Unit test


Fixes #6 