### PR TITLE
fix: go back to context.payload

### DIFF
--- a/__test__/action.test.mjs
+++ b/__test__/action.test.mjs
@@ -6,10 +6,9 @@ import assert from "node:assert";
  * Read the action.yml and create a function from the script inside.
  * replacing {{ inputs.* }} with ctx
  *
- * @param {*} ctx
  * @returns Function that requires a `context` and `core` parameter
  */
-function createTestFunction(ctx, title) {
+function createTestFunction() {
   const func = fs.readFileSync("./action.yml", "utf-8").split("script: |")[1];
 
   const newFunc = func
@@ -18,8 +17,8 @@ function createTestFunction(ctx, title) {
     .split("\n")
     .filter((f) => !f.includes("console.log"))
     .join("\n");
-  // process.stdout.write(newFunc)
-  return new Function("core", "__functionEnv", newFunc);
+  
+  return new Function("context", "core", "__functionEnv", newFunc);
 }
 
 function runAction(ctx, title) {
@@ -30,7 +29,6 @@ function runAction(ctx, title) {
     CONVENTIONAL_SCOPES: ctx.conventionalScopes ?? "",
     JIRA: ctx.jira ?? "warn",
     JIRA_PROJECTS: ctx.jiraProjects ?? "",
-    PULL_REQUEST_TITLE: title,
   }
 
   const output = {};
@@ -48,8 +46,8 @@ function runAction(ctx, title) {
       output.outputs[key] = value;
     },
   };
+  action({ payload: { pull_request: { title } } }, core, functionEnv);
 
-  action(core, functionEnv);
 
   return output;
 }

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,6 @@ runs:
         JIRA_PROJECTS: ${{ inputs.jira-projects }}
         CONVENTIONAL: ${{ inputs.conventional }}
         CONVENTIONAL_SCOPES: ${{ inputs.conventional-scopes }}
-        PULL_REQUEST_TITLE: ${{ context.payload.pull_request.title }}
       with:
         script: |
           try {
@@ -60,7 +59,7 @@ runs:
               }
             }
 
-            const title = process.env.PULL_REQUEST_TITLE;
+            const title = context.payload.pull_request.title;
             console.log(`Testing title: '${title}'`)
 
             // The pattern for JIRA ticket format


### PR DESCRIPTION
#### Motivation

Master is broken due to `context` being a script parameter and not text replaced.

#### Modification

Move back to the `context.payload.pull_request.title` as `context` is parsed from JSON and not replaced.

