### PR TITLE
docs: add copilot setup steps, copilot instructions, and CLAUDE.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+A composite GitHub Action that lints pull request titles for conventional-commit format and a JIRA ticket reference. No build step, no dependencies — logic lives inline in `action.yml` via `actions/github-script`.
+
+## Layout
+
+- `action.yml` — the entire action: inputs (`conventional`, `conventional-scopes`, `jira`, `jira-projects`, each accepting `error`/`warn`/`off`), outputs (`jira-issue-key`, `commit-type`, `commit-scope`), and a single composite step running an inline script against `context.payload.pull_request.title`.
+- `__test__/action.test.mjs` — tests using Node's built-in test runner, run with `node --test`.
+
+## Development commands
+
+```bash
+node --test   # runs __test__/action.test.mjs directly, no build/install needed
+```
+
+## Key conventions
+
+**All logic lives in `action.yml`**: there's no `src/` or `dist/` — edits to the regex/validation logic go directly into the inline `actions/github-script` step in `action.yml`. Don't introduce a separate build pipeline for this repo without good reason.
+
+**Conventional commit regex**: type is one of `build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|release`; scope is optional and constrained by `conventional-scopes` if provided; a trailing `!` (breaking change) is allowed. Update the regex in `action.yml` carefully — it's the single source of truth for what titles pass CI across every LINZ repo using this action.
+
+**JIRA regex**: defaults to `[A-Z]+-\d+` (any uppercase project key); when `jira-projects` is set, only those project keys match. `jira` defaults to `warn`, `conventional` defaults to `error` — a repo can loosen/tighten independently per input.
+
+**`warnOrFail` helper**: any new error-mode input should reuse this pattern (`error` → `core.setFailed`, `warn` → `core.warning`, `off` → skip) rather than duplicating the branching.
+
+**Consumers pin `@v1`** in the README example — check `.github/workflows/push.yml`/release process before assuming SHA-pinning is enforced for *this* action's own workflows (its own CI currently uses tag refs like `@v6`, not SHAs — new workflows added to this repo should still follow the org-wide SHA-pinning convention going forward).

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,29 @@
+name: Copilot Setup Steps
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: linz/action-setup-node@bd3af11c6f555ca817c163bf87104f9b2fafd282 # v1.0.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+@.github/copilot-instructions.md


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/copilot-setup-steps.yml` (checkout + `linz/action-setup-node`, no install step since this repo has no dependencies). All actions pinned to commit SHA.
- Adds `.github/copilot-instructions.md` covering the inline `action.yml` logic (no src/dist), the conventional-commit and JIRA regex conventions, and the `warnOrFail` pattern.
- Adds `CLAUDE.md` referencing the copilot instructions so Claude Code picks up the same guidance.

Part of a step-enablement-wide rollout of Copilot/Claude onboarding docs across team repos.